### PR TITLE
Add multiline support for offsetWidth

### DIFF
--- a/compatibility/Highcharts/compat.js
+++ b/compatibility/Highcharts/compat.js
@@ -20,13 +20,30 @@ if(!intrface.prototype.createSVGRect) {
 /*
 * Lack of offsetHeight/Width support - there is no real workaround..
 * This hack just assumes that each character in a string will add around 8 px
-* to its width. This obviously fails to handle multi-line strings! :-(
+* to its width.
+* 2019-07-16: try to add multiline support when jQuery is available.
+* This works best when 'useHTML' is enabled for labels etc.
 */
+function get_multiline_maxwidth(node) {
+    if(jQuery === undefined) {
+        return node.textContent.length;  // fallback without jQuery
+    }
+    var newline_tags = /(<\/h\d>|<\/p>|<br>)/,  // HTML tags which indicates a newline (blocked elements endtag also needed)
+        html = jQuery(node).html(),
+        txt_length = 0;
+    html.split(newline_tags).forEach(function(line) {
+        var txt = line.replace(/<[^>]*>?/gm, '');
+        if(txt.length > txt_length) txt_length = txt.length;  // determine longest line
+        console.log(html + " | " + line);
+    });
+    return txt_length;
+}
 
 Object.defineProperty(Element.prototype, 'offsetWidth', {
     get: function(){
         //console.log('Wants offsetWidth of ' + this + ', ' + this.textContent);
-        return parseInt(this.textContent.length * 8, 10);
+        var txtWidth = get_multiline_maxwidth(this);
+        return parseInt(txtWidth * 8, 10);
     }
 });
 

--- a/compatibility/Highcharts/compat.js
+++ b/compatibility/Highcharts/compat.js
@@ -34,7 +34,6 @@ function get_multiline_maxwidth(node) {
     html.split(newline_tags).forEach(function(line) {
         var txt = line.replace(/<[^>]*>?/gm, '');
         if(txt.length > txt_length) txt_length = txt.length;  // determine longest line
-        console.log(html + " | " + line);
     });
     return txt_length;
 }


### PR DESCRIPTION
I've came accross your script and it pretty much does what it should. My approach for multiline `offsetWidth` support is not 100% accurate, but better than nothing. Maybe worth a try? At least it does the trick for our project with `useHTML` enabled labels/titles etc...