### PR TITLE
Add MathJax compatibility script

### DIFF
--- a/compatibility/MathJax/README.md
+++ b/compatibility/MathJax/README.md
@@ -1,0 +1,29 @@
+# MathJax Compatibility
+
+This script allows Prince to render mathematics with [MathJax](https://www.mathjax.org/).
+
+## Sample HTML
+
+The following document shows how use MathJax with Prince. Note that when running Prince the `--javascript` option must be supplied.
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>MathJax SVG Example</title>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script src="compat.js"></script><!-- script from prince-scripts -->
+  <script id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
+</head>
+<body>
+  <h1>MathJax Sample</h1>
+
+  <p>
+    When \(a \ne 0\), there are two solutions to \(ax^2 + bx + c = 0\) and they are
+    \[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]
+  </p>
+</body>
+</html>
+```

--- a/compatibility/MathJax/compat.js
+++ b/compatibility/MathJax/compat.js
@@ -1,0 +1,49 @@
+// Source: https://gist.github.com/juliocesar/926500#gistcomment-2619473
+(function (isStorage) {
+    if (!isStorage) {
+        function Storage() { };
+        Storage.prototype.setItem = function (id, val) {
+            return this[id] = JSON.stringify(val);
+        }
+        Storage.prototype.getItem = function (id) {
+            return this.hasOwnProperty(id) ? this[id] : null;
+        }
+        Storage.prototype.removeItem = function (id) {
+            return delete this[id];
+        }
+        Storage.prototype.clear = function () {
+            var self = this;
+            Object.keys(this).map(function (key) { self.removeItem(key) });
+        }
+        window.localStorage = new Storage();
+    }
+})((function () {
+    try {
+        return "localStorage" in window && window.localStorage != null;
+    } catch (e) {
+        return false;
+    }
+})());
+
+if (!Element.prototype.getBoundingClientRect) {
+    Element.prototype.getBoundingClientRect = function() {
+        var x = 0, y = 0, width = 0, height = 0;
+        return {
+            x: x,
+            y: y,
+            width: width,
+            height: height,
+            top: y,
+            right: x + width,
+            bottom: y + height,
+            left: x
+        };
+    }
+}
+
+window.MathJax = {
+    options: {
+        enableAssistiveMml: false,
+        enableMenu: false
+    }
+};


### PR DESCRIPTION
As of latest build prince-20210526 Prince can now render MathJax to either SVG or HTML (`chtml`). These changes show how to use it.